### PR TITLE
Update support for web of science

### DIFF
--- a/js/ccf.js
+++ b/js/ccf.js
@@ -26,6 +26,10 @@ ccf.getRankInfo = function (refine, type) {
             url = res ? ccf.fullUrl[res] : false;
         }
         rank = ccf.rankUrl[url];
+    } else if (type == 'meeting') {
+        let full = ccf.abbrFull[refine];
+        url = ccf.fullUrl[full];
+        rank = ccf.rankUrl[url];
     } else {
         url = ccf.fullUrl[refine];
         rank = ccf.rankUrl[url];

--- a/js/wos.js
+++ b/js/wos.js
@@ -18,13 +18,46 @@ wos.run = function () {
 };
 
 wos.appendRanks = function () {
-    let elements = $("button[lang='en']");
-    elements.each(function () {
+    let publication_elements = $(".summary-source-title-link[lang='en']");
+    publication_elements.each(function () {
         let node = $(this);
         if (!node.next().hasClass("ccf-rank")) {
             for (let getRankSpan of wos.rankSpanList) {
                 let publication = node.text();
                 node.after(getRankSpan(publication, "publication"));
+            }
+        }
+    });
+    let meeting_elements = $("[name='conf_title'");
+    meeting_elements.each(function () {
+        let node = $(this);
+        if (!node.next().hasClass("ccf-rank")) {
+            for (let getRankSpan of wos.rankSpanList) {
+                let meeting = "";
+                let options = node.text().match(/\((.+?)\)/g);
+                let items = [];
+                if (options) {
+                    for (let m of options) {
+                        let short_name = m.substring(1, m.length - 1).split(/\s+/);
+                        let tmp_name = [];
+                        for (let name of short_name) {
+                            if (name.match(/^[0-9]*$/)) {
+                                continue;
+                            } else {
+                                tmp_name.push(name);
+                            }
+                        }
+                        meeting = tmp_name.join(" ");
+                        console.log(meeting);
+                        items.push(getRankSpan(meeting, "meeting"));
+                    } 
+                }
+
+                if (meeting == "") {
+                    console.log("not found", meeting);
+                    items.push(getRankSpan(meeting, "meeting"));
+                }
+                node.after(items);
             }
         }
     });

--- a/js/wos.js
+++ b/js/wos.js
@@ -18,8 +18,7 @@ wos.run = function () {
 };
 
 wos.appendRanks = function () {
-    let publication_elements = $(".summary-source-title-link[lang='en']");
-    publication_elements.each(function () {
+    $(".summary-source-title-link[lang='en']").each(function () {
         let node = $(this);
         if (!node.next().hasClass("ccf-rank")) {
             for (let getRankSpan of wos.rankSpanList) {
@@ -28,8 +27,16 @@ wos.appendRanks = function () {
             }
         }
     });
-    let meeting_elements = $("[name='conf_title'");
-    meeting_elements.each(function () {
+    $(".summary-source-title[lang='en']").each(function () {
+        let node = $(this);
+        if (!node.next().hasClass("ccf-rank")) {
+            for (let getRankSpan of wos.rankSpanList) {
+                let publication = node.text();
+                node.after(getRankSpan(publication, "publication"));
+            }
+        }
+    });
+    $("[name='conf_title']").each(function () {
         let node = $(this);
         if (!node.next().hasClass("ccf-rank")) {
             for (let getRankSpan of wos.rankSpanList) {
@@ -48,13 +55,11 @@ wos.appendRanks = function () {
                             }
                         }
                         meeting = tmp_name.join(" ");
-                        console.log(meeting);
                         items.push(getRankSpan(meeting, "meeting"));
                     } 
                 }
 
                 if (meeting == "") {
-                    console.log("not found", meeting);
                     items.push(getRankSpan(meeting, "meeting"));
                 }
                 node.after(items);


### PR DESCRIPTION
更新了`js/wos.js`和`js/ccf.js`以支持目前版本的web of science网站，注意到对于期刊和会议有三种形式的html元素：
1. 链接形式的期刊名（class为summary-source-title-link的元素）
2. 文本形式的期刊名或会议名（class为summary-source-title的元素）
3. 文本形式的会议名（name为conf_title的元素）

其中，来自会议的文章一定包含3，然后加上1或2。来自期刊的文章则是含有1或2。

`js/wos.js`中的修改是对以上三种元素的支持。
`js/ccf.js`中的修改是增加了一种通过全名获取rank的分支。

ps: 如果有什么不足请指出~