### PR TITLE
fix for CCFrank4dblp repeating dblp API queries over and over again

### DIFF
--- a/js/apiCache.js
+++ b/js/apiCache.js
@@ -1,0 +1,35 @@
+
+const apiCache = {};
+
+// cached values become stale after (86400000 = 24h) millisecs
+apiCache.expiresAfter = 86400000;
+
+// save a key-value pair to cache
+apiCache.setItem = function ( key, value ) {
+
+    let now = new Date();
+    let item = { value: value, expires: now.getTime() + apiCache.expiresAfter }
+    return localStorage.setItem( key, JSON.stringify(item) )
+};
+
+// get cached value of key
+apiCache.getItem = function ( key ) {
+
+    let itemStr = localStorage.getItem(key);
+    if( itemStr == null ) return null;
+
+    let now = new Date();
+    let item = JSON.parse(itemStr)
+
+    if( item == null || now.getTime() > item.expires ) {
+	localStorage.removeItem( key );
+	return null;
+    }
+    return item.value;
+};
+
+// remove cached value for key
+apiCache.removeItem = function ( key ) {
+
+    return localStorage.removeItem( key );
+};

--- a/js/connectedpapers.js
+++ b/js/connectedpapers.js
@@ -34,7 +34,7 @@ connectedpapers.appendRank = function () {
 
 connectedpapers.appendRanks = function () {
     let elements = $(".list-group-item-mod.minilist-list-entry");
-    elements.each(function () {
+    elements.each(function( index ) {
         let nodes = $(this).find(".horizontal-flexbox");
         let titlenode = nodes[0];
         let datanode = $(nodes[1]).find("div");
@@ -42,6 +42,8 @@ connectedpapers.appendRanks = function () {
         let title = titlenode.innerText;
         let author = (datanode[0].innerText).split(/[\s.,]+/)[1];
         let year = datanode[1].innerText;
-        fetchRank($(titlenode).find("h5"), title, author, year, connectedpapers);
+        setTimeout(function() {
+            fetchRank($(titlenode).find("h5"), title, author, year, connectedpapers);
+        }, 100 * index );
     });
 };

--- a/js/scholar.js
+++ b/js/scholar.js
@@ -24,7 +24,7 @@ scholar.run = function () {
 
 scholar.appendRank = function () {
     let elements = $("#gs_res_ccl_mid > div > div.gs_ri");
-    elements.each(function () {
+    elements.each(function( index ) {
         let node = $(this).find("h3 > a");
         if (!node.next().hasClass("ccf-rank")) {
             let title = node.text();
@@ -35,14 +35,16 @@ scholar.appendRank = function () {
                 .split(" ");
             let author = data[1];
             let year = data.slice(-3)[0];
-            fetchRank(node, title, author, year, scholar);
+            setTimeout(function() {
+                fetchRank(node, title, author, year, scholar);
+            }, 100 * index );
         }
     });
 };
 
 scholar.appendRanks = function () {
     let elements = $("tr.gsc_a_tr");
-    elements.each(function () {
+    elements.each(function( index ) {
         let node = $(this).find("td.gsc_a_t > a").first();
         if (!node.next().hasClass("ccf-rank")) {
             let title = node.text();
@@ -52,7 +54,9 @@ scholar.appendRanks = function () {
                 .replace(/[\,\…]/g, "")
                 .split(" ")[1];
             let year = $(this).find("td.gsc_a_y").text();
-            fetchRank(node, title, author, year, scholar);
+            setTimeout(function() {
+                fetchRank(node, title, author, year, scholar);
+            }, 100 * index );
         }
     });
 };


### PR DESCRIPTION
- added js/apiCache.js to allow persistently storing data in browser's localStorage with a default expiration time of one day
- improved fetchRank() in order to cache and reuse query results; this should avoid the thousands of redundant queries

NOTE: not thoroughly tested, please check before using